### PR TITLE
Night of Vespers Encounter Sets

### DIFF
--- a/projects/night_of_vespers_campaign_expansion.json
+++ b/projects/night_of_vespers_campaign_expansion.json
@@ -49,7 +49,7 @@
         "back_link": "23c8cd6a-734b-44d1-b194-ae8c228e972f-back",
         "code": "23c8cd6a-734b-44d1-b194-ae8c228e972f",
         "doom": 1,
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 2,
         "faction_code": "mythos",
         "flavor": "As the hour of your mysterious dinner companion's arrival draws near, you find yourself in need of a distraction. While the Trattoria del Parche's much-acclaimed floor show offers a modest reprieve from your growing boredom and anxiety, the complementary bottle of wine at your table has been a much more direct way to help ease the passage of time. \nYou sneak a glance at the clock. Surely you can't be expected to wait for much longer, can you?",
@@ -66,7 +66,7 @@
       },
       {
         "code": "23c8cd6a-734b-44d1-b194-ae8c228e972f-back",
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 2,
         "faction_code": "mythos",
         "hidden": true,
@@ -83,7 +83,7 @@
         "back_link": "a2eab455-b2f6-4cbb-9ca0-e15fc7039257-back",
         "code": "a2eab455-b2f6-4cbb-9ca0-e15fc7039257",
         "doom": 6,
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 3,
         "faction_code": "mythos",
         "flavor": "Screams echo throughout the Hotel Seasons. You keep your head low and prepare to bolt at the first sign of a lull in the gunfire.",
@@ -100,7 +100,7 @@
       },
       {
         "code": "a2eab455-b2f6-4cbb-9ca0-e15fc7039257-back",
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 3,
         "faction_code": "mythos",
         "hidden": true,
@@ -117,7 +117,7 @@
         "back_link": "8846f6b5-6daf-475d-a666-11700f8b054f-back",
         "code": "8846f6b5-6daf-475d-a666-11700f8b054f",
         "doom": 9,
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 4,
         "faction_code": "mythos",
         "flavor": "Time has become your enemy. The hatchetmen on your tail are growing closer with each passing moment.",
@@ -134,7 +134,7 @@
       },
       {
         "code": "8846f6b5-6daf-475d-a666-11700f8b054f-back",
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 4,
         "faction_code": "mythos",
         "hidden": true,
@@ -150,7 +150,7 @@
       {
         "back_link": "e1df8508-914e-4f8a-b11c-3e9985e49cc3-back",
         "code": "e1df8508-914e-4f8a-b11c-3e9985e49cc3",
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 5,
         "faction_code": "mythos",
         "flavor": "You can't help but steal another glance back at the table of O'Bannion men you noticed when you first entered the restaurant. The grande dame at the far end of the table departs to powder her nose, but not before leaning down to give the elderly gent at the head of the table a gentle kiss on the cheek.\nIsn't it nice to see that romance is alive and well, even in these curious times?",
@@ -167,7 +167,7 @@
       },
       {
         "code": "e1df8508-914e-4f8a-b11c-3e9985e49cc3-back",
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 5,
         "faction_code": "mythos",
         "hidden": true,
@@ -183,7 +183,7 @@
         "back_link": "4010f817-3c9e-4072-be7c-ad57adcbce65-back",
         "clues": 2,
         "code": "4010f817-3c9e-4072-be7c-ad57adcbce65",
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 6,
         "faction_code": "mythos",
         "flavor": "A stray bullet ricochets into a porcelain vase just behind your head, shattering it into pieces. Unless you intend to finish out your evening in the back of a hearse, you need to get out of this restaurant, fast.",
@@ -200,7 +200,7 @@
       },
       {
         "code": "4010f817-3c9e-4072-be7c-ad57adcbce65-back",
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 6,
         "faction_code": "mythos",
         "hidden": true,
@@ -216,7 +216,7 @@
         "back_link": "683370b6-6849-48d3-b0f6-d6888cf855f7-back",
         "clues": 2,
         "code": "683370b6-6849-48d3-b0f6-d6888cf855f7",
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 7,
         "faction_code": "mythos",
         "flavor": "All this running, and you've only managed to wind your way back to where you began. With the hotel ablaze, your only hope now to survive the evening unscathed is to cut a path through the flames to an exit---any exit.",
@@ -233,7 +233,7 @@
       },
       {
         "code": "683370b6-6849-48d3-b0f6-d6888cf855f7-back",
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 7,
         "faction_code": "mythos",
         "hidden": true,
@@ -1140,7 +1140,7 @@
         "code": "9449e972-5d30-47a6-8e70-a3ae06813570",
         "cost": 3,
         "deck_limit": 1,
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 32,
         "faction_code": "neutral",
         "flavor": "\"Payback's the only thing I care about.\"",
@@ -1166,7 +1166,7 @@
         "code": "e9fd49ac-0d0a-469c-8194-4a42a2c0b268",
         "cost": 3,
         "deck_limit": 1,
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-seasons",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
         "encounter_position": 33,
         "faction_code": "neutral",
         "flavor": "\"Brains are an asset, if you can hide 'em.\"",
@@ -3929,7 +3929,7 @@
       {
         "code": "f09b21b4-ee1e-4e76-94c7-adcb5a1f2261",
         "double_sided": true,
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_icon_aradia_s_symbol_by_joycrux_dejq4tq-fullview",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_icon_aradia_s_symbol_by_joycrux_dejq4tq-fullview",
         "encounter_position": 17,
         "faction_code": "mythos",
         "name": "Shattered Reflections",
@@ -4995,7 +4995,7 @@
         "code": "dd46f76a-1edf-4660-9604-37049b084eb6",
         "cost": 5,
         "deck_limit": 1,
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_dan_onedrive_desktop_night_of_vespers_v2_07_images_trolley",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_trolley",
         "encounter_position": 23,
         "faction_code": "neutral",
         "flavor": "She has her mother's charm, her father's cunning, \nand a personal vendetta as deep as the sea.",
@@ -7688,7 +7688,7 @@
       },
       {
         "code": "9c0693a4-2132-4490-8c0b-52783aa41c53",
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_treble2",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_treble2",
         "encounter_position": 44,
         "faction_code": "mythos",
         "illustrator": "James Jean",
@@ -7771,7 +7771,7 @@
       {
         "back_link": "08936f5d-f08d-49d8-a9d1-12ec306c2d0b-back",
         "code": "08936f5d-f08d-49d8-a9d1-12ec306c2d0b",
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_dan_onedrive_desktop_night_of_vespers_v2_07_images_mercy",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_mercy",
         "encounter_position": 1,
         "faction_code": "mythos",
         "name": "Mother's Mercy",
@@ -7785,7 +7785,7 @@
       },
       {
         "code": "08936f5d-f08d-49d8-a9d1-12ec306c2d0b-back",
-        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_dan_onedrive_desktop_night_of_vespers_v2_07_images_mercy",
+        "encounter_code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_mercy",
         "encounter_position": 1,
         "faction_code": "mythos",
         "hidden": true,
@@ -10954,193 +10954,163 @@
     "encounter_sets": [
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_3moon",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\3moon",
+        "name": "Sacred Triad",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_3moon-encounter-set-icon.png?cachebust=1767688689856"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_astral_justice",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\astral justice",
+        "name": "Astral Justice",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_astral_justice-encounter-set-icon.png?cachebust=1767688690445"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_astral_requital",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\astral requital",
+        "name": "Astral Requital",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_astral_requital-encounter-set-icon.png?cachebust=1767688704124"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_astralcrossroads",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\astralcrossroads",
+        "name": "Astral Crossroads",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_astralcrossroads-encounter-set-icon.png?cachebust=1767688706191"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_camorra",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\camorra",
+        "name": "The Family",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_camorra-encounter-set-icon.png?cachebust=1767688689296"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_camorra_2_",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\camorra (2)",
+        "name": "The Commission",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_camorra_2_-encounter-set-icon.png?cachebust=1767688704460"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_cat",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\cat",
+        "name": "Agents of Sighs",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_cat-encounter-set-icon.png?cachebust=1767688688939"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_chalk",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\chalk",
+        "name": "Habeas Corpus",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_chalk-encounter-set-icon.png?cachebust=1767688688595"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_city",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\city",
+        "name": "Megapolisomancy",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_city-encounter-set-icon.png?cachebust=1767688698914"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_column",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\column",
+        "name": "Unhallowed Land",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_column-encounter-set-icon.png?cachebust=1767688687043"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_conies",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\conies",
+        "name": "Behind Closed Doors",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_conies-encounter-set-icon.png?cachebust=1767688688273"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_giallo",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\giallo",
+        "name": "Giallo!",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_giallo-encounter-set-icon.png?cachebust=1767688687454"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_glass",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\glass",
+        "name": "Hostile Architecture",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_glass-encounter-set-icon.png?cachebust=1767688695645"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_hekate_wheel",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\hekate wheel",
+        "name": "Three-Fold Evils",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_hekate_wheel-encounter-set-icon.png?cachebust=1767688700242"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_hildegard",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\hildegard",
+        "name": "The Garden of Bones",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_hildegard-encounter-set-icon.png?cachebust=1767688697933"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_icon_aradia_s_symbol_by_joycrux_dejq4tq-fullview",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\icon__aradia_s_symbol_by_joycrux_dejq4tq-fullview",
+        "name": "The Teachings of Aradia",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_icon_aradia_s_symbol_by_joycrux_dejq4tq-fullview-encounter-set-icon.png?cachebust=1767688709960"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_inferno2",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\inferno2",
+        "name": "Inferno",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_inferno2-encounter-set-icon.png?cachebust=1767688701073"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_infernoposter",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\infernoposter",
+        "name": "Tenebrae",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_infernoposter-encounter-set-icon.png?cachebust=1767688686428"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_lastdance",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\lastdance",
+        "name": "Last Dance",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_lastdance-encounter-set-icon.png?cachebust=1767688691001"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_liminal",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\liminal",
+        "name": "Liminal Spaces",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_liminal-encounter-set-icon.png?cachebust=1767688692823"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_mercy",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\mercy",
+        "name": "Mother's Mercy",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_mercy-encounter-set-icon.png?cachebust=1767688694088"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_moth",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\moth",
+        "name": "Agents of Darkness",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_moth-encounter-set-icon.png?cachebust=1767688710775"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_nyctophobia",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\nyctophobia",
+        "name": "Nyctophobia",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_nyctophobia-encounter-set-icon.png?cachebust=1767688702637"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_paranormal",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\paranormal",
+        "name": "Paranormal Activity",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_paranormal-encounter-set-icon.png?cachebust=1767688707483"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_phenomena",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\phenomena",
+        "name": "Phenomena",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_phenomena-encounter-set-icon.png?cachebust=1767688696388"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_raven",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\raven",
+        "name": "Agents of Tears",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_raven-encounter-set-icon.png?cachebust=1767688697176"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\seasons",
+        "name": "The End of Seasons",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_seasons-encounter-set-icon.png?cachebust=1767688702024"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_suspiria_3",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\suspiria 3",
+        "name": "Dancing with Death",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_suspiria_3-encounter-set-icon.png?cachebust=1767688711203"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_tears",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\tears",
+        "name": "Trauma",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_tears-encounter-set-icon.png?cachebust=1767688684922"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_treble2",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\treble2",
+        "name": "A Chorus of Suffering",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_treble2-encounter-set-icon.png?cachebust=1767688703227"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_trolley",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\trolley",
+        "name": "The City of Fog",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_trolley-encounter-set-icon.png?cachebust=1767688698624"
       },
       {
         "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_vivat_regina",
-        "name": "C:\\Users\\ahind\\Desktop\\gangster project\\icons\\Vivat Regina",
+        "name": "Vivat Regina",
         "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_ahind_desktop_gangster_project_icons_vivat_regina-encounter-set-icon.png?cachebust=1767688693405"
-      },
-      {
-        "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_dan_onedrive_desktop_night_of_vespers_v2_07_images_mercy",
-        "name": "C:\\Users\\dan\\OneDrive\\Desktop\\Night of Vespers_v2\\07 Images\\mercy",
-        "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_dan_onedrive_desktop_night_of_vespers_v2_07_images_mercy-encounter-set-icon.png?cachebust=1767688710388"
-      },
-      {
-        "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_dan_onedrive_desktop_night_of_vespers_v2_07_images_trolley",
-        "name": "C:\\Users\\dan\\OneDrive\\Desktop\\Night of Vespers_v2\\07 Images\\trolley",
-        "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-c_users_dan_onedrive_desktop_night_of_vespers_v2_07_images_trolley-encounter-set-icon.png?cachebust=1767688685713"
-      },
-      {
-        "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_icon_aradia_s_symbol_by_joycrux_dejq4tq-fullview",
-        "name": "F:\\gangster project\\icons\\icon__aradia_s_symbol_by_joycrux_dejq4tq-fullview",
-        "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_icon_aradia_s_symbol_by_joycrux_dejq4tq-fullview-encounter-set-icon.png?cachebust=1767688692147"
-      },
-      {
-        "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons",
-        "name": "F:\\gangster project\\icons\\seasons",
-        "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_seasons-encounter-set-icon.png?cachebust=1767688705508"
-      },
-      {
-        "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_treble2",
-        "name": "F:\\gangster project\\icons\\treble2",
-        "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-f_gangster_project_icons_treble2-encounter-set-icon.png?cachebust=1767688699544"
-      },
-      {
-        "code": "f565e2b2-97df-420c-ae07-7586fb74c7d7-seasons",
-        "name": "seasons",
-        "icon_url": "https://eons.arkham.build/f565e2b2-97df-420c-ae07-7586fb74c7d7-seasons-encounter-set-icon.png?cachebust=1767688694723"
       }
     ],
     "packs": [


### PR DESCRIPTION
Fix encounter set names to be normal, also removed some sets entirely, (where the Eons files were using different copies of the same image, for some reason), and re-pointed their cards to the main set.